### PR TITLE
Refactor Move, update clang-format rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,77 @@
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false

--- a/.clang-format
+++ b/.clang-format
@@ -75,3 +75,4 @@ PointerAlignment: Right
 ReflowComments:  true
 SortIncludes:    true
 SpaceAfterCStyleCast: false
+SpacesBeforeTrailingComments: 2

--- a/corintho_ai/cpp/include/game.h
+++ b/corintho_ai/cpp/include/game.h
@@ -33,7 +33,7 @@ class Game {
 
   void apply_line(uintf line, bitset<NUM_MOVES> &legal_moves) const;
 
-  bool is_legal_move(uintf move_id) const;
+  bool is_legal_move(int32_t move_id) const;
   bool can_place(uintf ptype, uintf row, uintf col) const;
   bool can_move(uintf row1, uintf col1, uintf row2, uintf col2) const;
   bool is_empty(uintf row, uintf col) const;
@@ -46,7 +46,7 @@ public:
   Game(long *board, int to_play, long *pieces);
   ~Game() = default;
 
-  void do_move(uintf move_id);
+  void do_move(int32_t move_id);
 
   // Returns whether there are lines
   bool get_legal_moves(bitset<NUM_MOVES> &legal_moves) const;

--- a/corintho_ai/cpp/include/move.h
+++ b/corintho_ai/cpp/include/move.h
@@ -17,7 +17,7 @@ public:
   Move &operator=(Move &&move) noexcept = default;
   ~Move() = default;
   // Construct a move from its id
-  explicit Move(int32_t id);
+  explicit Move(int32_t id) noexcept;
   // Construct a place move
   Move(int32_t piece_type, int32_t row, int32_t col);
   // Construct a move move
@@ -28,6 +28,7 @@ public:
   int32_t row1() const noexcept { return row1_; }
   int32_t col1() const noexcept { return col1_; }
   int32_t row2() const noexcept { return row2_; }
+  int32_t col2() const noexcept { return col2_; }
 
   friend std::ostream &operator<<(std::ostream &os, const Move &move);
 

--- a/corintho_ai/cpp/include/move.h
+++ b/corintho_ai/cpp/include/move.h
@@ -4,19 +4,37 @@
 #include "util.h"
 #include <ostream>
 
-struct Move {
+class Move {
+public:
+  enum MoveType { kPlace, kMove };
 
-  bool mtype;
-  uintf ptype, row1, col1, row2, col2;
+  Move() = delete;
+  Move(const Move &move) = default;
+  Move(Move &&move) = default;
+  Move &operator=(const Move &move) = default;
+  Move &operator=(Move &&move) = default;
+  ~Move() = default;
+  explicit Move(uintf move_id);
 
-  Move() = default;
-  Move(uintf move_id);
+  MoveType move_type() const noexcept { return move_type_; }
+  int32_t piece_type() const noexcept { return piece_type_; }
+  int32_t row1() const noexcept { return row1_; }
+  int32_t col1() const noexcept { return col1_; }
+  int32_t row2() const noexcept { return row2_; }
 
   friend std::ostream &operator<<(std::ostream &os, const Move &move);
+
+private:
+  MoveType move_type_;
+  int32_t piece_type_;
+  int32_t row1_;
+  int32_t col1_;
+  int32_t row2_;
+  int32_t col2_;
 };
 
-char get_col_name(uintf col);
-uintf encode_place(uintf ptype, uintf row, uintf col);
-uintf encode_move(uintf row1, uintf col1, uintf row2, uintf col2);
+char get_col_name(int32_t col);
+int32_t encode_place(int32_t ptype, int32_t row, int32_t col);
+int32_t encode_move(int32_t row1, int32_t col1, int32_t row2, int32_t col2);
 
 #endif

--- a/corintho_ai/cpp/include/move.h
+++ b/corintho_ai/cpp/include/move.h
@@ -1,20 +1,27 @@
 #ifndef MOVE_H
 #define MOVE_H
 
-#include "util.h"
 #include <ostream>
+
+#include "util.h"
 
 class Move {
 public:
-  enum MoveType { kPlace, kMove };
+  enum class MoveType { kPlace, kMove };
+  enum class Direction { kRight, kUp, kLeft, kDown };
 
   Move() = delete;
-  Move(const Move &move) = default;
-  Move(Move &&move) = default;
-  Move &operator=(const Move &move) = default;
-  Move &operator=(Move &&move) = default;
+  Move(const Move &move) noexcept = default;
+  Move(Move &&move) noexcept = default;
+  Move &operator=(const Move &move) noexcept = default;
+  Move &operator=(Move &&move) noexcept = default;
   ~Move() = default;
-  explicit Move(uintf move_id);
+  // Construct a move from its id
+  explicit Move(int32_t id);
+  // Construct a place move
+  Move(int32_t piece_type, int32_t row, int32_t col);
+  // Construct a move move
+  Move(int32_t row, int32_t col, Direction direction);
 
   MoveType move_type() const noexcept { return move_type_; }
   int32_t piece_type() const noexcept { return piece_type_; }
@@ -29,12 +36,15 @@ private:
   int32_t piece_type_;
   int32_t row1_;
   int32_t col1_;
-  int32_t row2_;
-  int32_t col2_;
+  int32_t row2_{0};
+  int32_t col2_{0};
 };
 
-char get_col_name(int32_t col);
-int32_t encode_place(int32_t ptype, int32_t row, int32_t col);
-int32_t encode_move(int32_t row1, int32_t col1, int32_t row2, int32_t col2);
+// Convert place move to its id
+int32_t encodePlace(int32_t ptype, int32_t row, int32_t col);
+// Convert move move to its id
+int32_t encodeMove(int32_t row1, int32_t col1, int32_t row2, int32_t col2);
+// Convert column index to its name (a, b, c, d)
+char getColName(int32_t col);
 
 #endif

--- a/corintho_ai/cpp/src/game.cpp
+++ b/corintho_ai/cpp/src/game.cpp
@@ -1,7 +1,9 @@
 #include "game.h"
+
+#include <ostream>
+
 #include "move.h"
 #include "util.h"
-#include <ostream>
 
 Game::Game() : to_play{0}, pieces{4, 4, 4, 4, 4, 4} {}
 
@@ -15,7 +17,7 @@ Game::Game(long *board, int to_play, long *pieces)
   }
 }
 
-void Game::do_move(uintf move_id) {
+void Game::do_move(int32_t move_id) {
 
   Move move{move_id};
 
@@ -27,20 +29,20 @@ void Game::do_move(uintf move_id) {
   }
 
   // Place
-  if (move.mtype) {
-    --pieces[to_play * 3 + move.ptype];
-    set_board(move.row1, move.col1, move.ptype);
-    set_frozen(move.row1, move.col1);
+  if (move.move_type() == Move::MoveType::kPlace) {
+    --pieces[to_play * 3 + move.piece_type()];
+    set_board(move.row1(), move.col1(), move.piece_type());
+    set_frozen(move.row1(), move.col1());
   }
   // Move
   else {
     for (uintf i = 0; i < 3; ++i) {
-      set_board(move.row2, move.col2, i,
-                get_board(move.row1, move.col1, i) ||
-                    get_board(move.row2, move.col2, i));
-      set_board(move.row1, move.col1, i, false);
+      set_board(move.row2(), move.col2(), i,
+                get_board(move.row1(), move.col1(), i) ||
+                    get_board(move.row2(), move.col2(), i));
+      set_board(move.row1(), move.col1(), i, false);
     }
-    set_frozen(move.row2, move.col2, true);
+    set_frozen(move.row2(), move.col2(), true);
   }
   to_play = 1 - to_play;
 }
@@ -126,7 +128,7 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
   // Rows
   for (uintf i = 0; i < 4; ++i) {
     space_1 = get_top(i, 1);
-    if (space_1 != -1) { // If not empty
+    if (space_1 != -1) {  // If not empty
       space_2 = get_top(i, 2);
       if (space_1 == space_2) {
         space_0 = get_top(i, 0), space_3 = get_top(i, 3);
@@ -142,18 +144,18 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
               // We don't need to know which row it is
               // If it is wrong, the move is illegal anyways
               if (!get_board(0, 3, 2)) {
-                legal_moves[encode_move(0, 3, 1, 3)] = false;
+                legal_moves[encodeMove(0, 3, 1, 3)] = false;
               }
               if (!get_board(1, 3, 2)) {
-                legal_moves[encode_move(1, 3, 0, 3)] = false;
-                legal_moves[encode_move(1, 3, 2, 3)] = false;
+                legal_moves[encodeMove(1, 3, 0, 3)] = false;
+                legal_moves[encodeMove(1, 3, 2, 3)] = false;
               }
               if (!get_board(2, 3, 2)) {
-                legal_moves[encode_move(2, 3, 1, 3)] = false;
-                legal_moves[encode_move(2, 3, 3, 3)] = false;
+                legal_moves[encodeMove(2, 3, 1, 3)] = false;
+                legal_moves[encodeMove(2, 3, 3, 3)] = false;
               }
               if (!get_board(3, 3, 2)) {
-                legal_moves[encode_move(3, 3, 2, 3)] = false;
+                legal_moves[encodeMove(3, 3, 2, 3)] = false;
               }
             }
           }
@@ -163,18 +165,18 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
           if (space_3 == 2) {
             // Capital must be used to extend line when moving
             if (!get_board(0, 0, 2)) {
-              legal_moves[encode_move(0, 0, 1, 0)] = false;
+              legal_moves[encodeMove(0, 0, 1, 0)] = false;
             }
             if (!get_board(1, 0, 2)) {
-              legal_moves[encode_move(1, 0, 0, 0)] = false;
-              legal_moves[encode_move(1, 0, 2, 0)] = false;
+              legal_moves[encodeMove(1, 0, 0, 0)] = false;
+              legal_moves[encodeMove(1, 0, 2, 0)] = false;
             }
             if (!get_board(2, 0, 2)) {
-              legal_moves[encode_move(2, 0, 1, 0)] = false;
-              legal_moves[encode_move(2, 0, 3, 0)] = false;
+              legal_moves[encodeMove(2, 0, 1, 0)] = false;
+              legal_moves[encodeMove(2, 0, 3, 0)] = false;
             }
             if (!get_board(3, 0, 2)) {
-              legal_moves[encode_move(3, 0, 2, 0)] = false;
+              legal_moves[encodeMove(3, 0, 2, 0)] = false;
             }
           }
         }
@@ -185,7 +187,7 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
   // Columns
   for (uintf j = 0; j < 4; ++j) {
     space_1 = get_top(1, j);
-    if (space_1 != -1) { // If not empty
+    if (space_1 != -1) {  // If not empty
       space_2 = get_top(2, j);
       if (space_1 == space_2) {
         space_0 = get_top(0, j), space_3 = get_top(3, j);
@@ -201,18 +203,18 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
               // We don't need to know which column it is
               // If it is wrong, the move is illegal anyways
               if (!get_board(3, 0, 2)) {
-                legal_moves[encode_move(3, 0, 3, 1)] = false;
+                legal_moves[encodeMove(3, 0, 3, 1)] = false;
               }
               if (!get_board(3, 1, 2)) {
-                legal_moves[encode_move(3, 1, 3, 0)] = false;
-                legal_moves[encode_move(3, 1, 3, 2)] = false;
+                legal_moves[encodeMove(3, 1, 3, 0)] = false;
+                legal_moves[encodeMove(3, 1, 3, 2)] = false;
               }
               if (!get_board(3, 2, 2)) {
-                legal_moves[encode_move(3, 2, 3, 1)] = false;
-                legal_moves[encode_move(3, 2, 3, 3)] = false;
+                legal_moves[encodeMove(3, 2, 3, 1)] = false;
+                legal_moves[encodeMove(3, 2, 3, 3)] = false;
               }
               if (!get_board(3, 3, 2)) {
-                legal_moves[encode_move(3, 3, 3, 2)] = false;
+                legal_moves[encodeMove(3, 3, 3, 2)] = false;
               }
             }
           }
@@ -224,18 +226,18 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
             // We don't need to know which column it is
             // If it is wrong, the move is illegal anyways
             if (!get_board(0, 0, 2)) {
-              legal_moves[encode_move(0, 0, 0, 1)] = false;
+              legal_moves[encodeMove(0, 0, 0, 1)] = false;
             }
             if (!get_board(0, 1, 2)) {
-              legal_moves[encode_move(0, 1, 0, 0)] = false;
-              legal_moves[encode_move(0, 1, 0, 2)] = false;
+              legal_moves[encodeMove(0, 1, 0, 0)] = false;
+              legal_moves[encodeMove(0, 1, 0, 2)] = false;
             }
             if (!get_board(0, 2, 2)) {
-              legal_moves[encode_move(0, 2, 0, 1)] = false;
-              legal_moves[encode_move(0, 2, 0, 3)] = false;
+              legal_moves[encodeMove(0, 2, 0, 1)] = false;
+              legal_moves[encodeMove(0, 2, 0, 3)] = false;
             }
             if (!get_board(0, 3, 2)) {
-              legal_moves[encode_move(0, 3, 0, 2)] = false;
+              legal_moves[encodeMove(0, 3, 0, 2)] = false;
             }
           }
         }
@@ -245,7 +247,7 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
 
   // Upper left to lower right long diagonal
   space_1 = get_top(1, 1);
-  if (space_1 != -1) { // If not empty
+  if (space_1 != -1) {  // If not empty
     space_2 = get_top(2, 2);
     if (space_1 == space_2) {
       space_0 = get_top(0, 0), space_3 = get_top(3, 3);
@@ -259,10 +261,10 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
           if (space_0 == 2) {
             // Capital must be used to extend line when moving
             if (!get_board(2, 3, 2)) {
-              legal_moves[encode_move(2, 3, 3, 3)] = false;
+              legal_moves[encodeMove(2, 3, 3, 3)] = false;
             }
             if (!get_board(3, 2, 2)) {
-              legal_moves[encode_move(3, 2, 3, 3)] = false;
+              legal_moves[encodeMove(3, 2, 3, 3)] = false;
             }
           }
         }
@@ -272,10 +274,10 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
         if (space_3 == 2) {
           // Capital must be used to extend line when moving
           if (!get_board(0, 1, 2)) {
-            legal_moves[encode_move(0, 1, 0, 0)] = false;
+            legal_moves[encodeMove(0, 1, 0, 0)] = false;
           }
           if (!get_board(1, 0, 2)) {
-            legal_moves[encode_move(1, 0, 0, 0)] = false;
+            legal_moves[encodeMove(1, 0, 0, 0)] = false;
           }
         }
       }
@@ -284,7 +286,7 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
 
   // Upper right to lower left long diagonal
   space_1 = get_top(1, 2);
-  if (space_1 != -1) { // If not empty
+  if (space_1 != -1) {  // If not empty
     space_2 = get_top(2, 1);
     if (space_1 == space_2) {
       space_0 = get_top(0, 3), space_3 = get_top(3, 0);
@@ -298,10 +300,10 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
           if (space_0 == 2) {
             // Capital must be used to extend line when moving
             if (!get_board(2, 0, 2)) {
-              legal_moves[encode_move(2, 0, 3, 0)] = false;
+              legal_moves[encodeMove(2, 0, 3, 0)] = false;
             }
             if (!get_board(3, 1, 2)) {
-              legal_moves[encode_move(3, 1, 3, 0)] = false;
+              legal_moves[encodeMove(3, 1, 3, 0)] = false;
             }
           }
         }
@@ -311,10 +313,10 @@ bool Game::get_line_breakers(bitset<NUM_MOVES> &legal_moves) const {
         if (space_3 == 2) {
           // Capital must be used to extend line when moving
           if (!get_board(0, 2, 2)) {
-            legal_moves[encode_move(0, 2, 0, 3)] = false;
+            legal_moves[encodeMove(0, 2, 0, 3)] = false;
           }
           if (!get_board(1, 3, 2)) {
-            legal_moves[encode_move(1, 3, 0, 3)] = false;
+            legal_moves[encodeMove(1, 3, 0, 3)] = false;
           }
         }
       }
@@ -390,13 +392,13 @@ void Game::apply_line(uintf line, bitset<NUM_MOVES> &legal_moves) const {
   legal_moves &= line_breakers[line];
 }
 
-bool Game::is_legal_move(uintf move_id) const {
+bool Game::is_legal_move(int32_t move_id) const {
   Move move{move_id};
   // Place
-  if (move.mtype)
-    return can_place(move.ptype, move.row1, move.col1);
+  if (move.move_type() == Move::MoveType::kPlace)
+    return can_place(move.piece_type(), move.row1(), move.col1());
   // Move
-  return can_move(move.row1, move.col1, move.row2, move.col2);
+  return can_move(move.row1(), move.col1(), move.row2(), move.col2());
 }
 
 bool Game::can_place(uintf ptype, uintf row, uintf col) const {

--- a/corintho_ai/cpp/src/move.cpp
+++ b/corintho_ai/cpp/src/move.cpp
@@ -16,23 +16,23 @@ Move::Move(int32_t id) noexcept
     row1_ = (id % 16) / 4;
     col1_ = id % 4;
   }
-  // Move
-  else if (id < 12) { // Right
+  // Move move
+  else if (id < 12) {  // Right
     row1_ = id / 3;
     col1_ = id % 3;
     row2_ = row1_;
     col2_ = col1_ + 1;
-  } else if (id < 24) { // Down
+  } else if (id < 24) {  // Down
     row1_ = (id - 12) / 4;
     col1_ = id % 4;
     row2_ = row1_ + 1;
     col2_ = col1_;
-  } else if (id < 36) { // Left
+  } else if (id < 36) {  // Left
     row1_ = (id - 24) / 3;
     col1_ = id % 3 + 1;
     row2_ = row1_;
     col2_ = col1_ - 1;
-  } else { // Up
+  } else {  // Up
     row1_ = (id - 32) / 4;
     col1_ = id % 4;
     row2_ = row1_ - 1;
@@ -52,25 +52,25 @@ int32_t encodeMove(int32_t row1, int32_t col1, int32_t row2, int32_t col2) {
   assert(col1 >= 0 && col1 < 4);
   assert(row2 >= 0 && row2 < 4);
   assert(col2 >= 0 && col2 < 4);
-  if (col1 < col2) { // Right
+  if (col1 < col2) {  // Right
     assert(row1 == row2);
     assert(col1 + 1 == col2);
     return row1 * 3 + col1;
   }
-  if (row1 < row2) { // Down
+  if (row1 < row2) {  // Down
     assert(col1 == col2);
     assert(row1 + 1 == row2);
     return 12 + row1 * 4 + col1;
   }
-  if (col1 > col2) { // Left
+  if (col1 > col2) {  // Left
     assert(row1 == row2);
     assert(col1 - 1 == col2);
-    return 24 + row1 * 3 + col1 - 1;
+    return 24 + row1 * 3 + (col1 - 1);
   }
   // Up
   assert(col1 == col2);
   assert(row1 - 1 == row2);
-  return 36 + row1 * 4 + col1;
+  return 36 + (row1 - 1) * 4 + col1;
 }
 
 char getColName(int32_t col) {
@@ -83,7 +83,7 @@ char getColName(int32_t col) {
     return 'c';
   case 3:
     return 'd';
-  default: // Should never happen
+  default:  // Should never happen
     assert(false);
     return ' ';
   }

--- a/corintho_ai/cpp/src/playmc.cpp
+++ b/corintho_ai/cpp/src/playmc.cpp
@@ -321,7 +321,7 @@ bool PlayMC::search() {
         float u = cur->get_probability(edge_index) * v_sqrt;
         if (u > max_value) {
           best_prev_node =
-              prev_node; // This should always be the last node in the list
+              prev_node;  // This should always be the last node in the list
           max_value = u;
           move_choice = cur->edges[edge_index].move_id;
         }
@@ -490,18 +490,26 @@ void PlayMC::get_legal_moves(long *legal_moves) const {
   }
 }
 
-uintf PlayMC::get_node_number() const { return root->count_nodes(); }
+uintf PlayMC::get_node_number() const {
+  return root->count_nodes();
+}
 
-float PlayMC::get_evaluation() const { return root->evaluation; }
+float PlayMC::get_evaluation() const {
+  return root->evaluation;
+}
 
 bool PlayMC::is_done() const {
   return root->result == RESULT_WIN || root->result == RESULT_DRAW ||
          root->result == RESULT_LOSS;
 }
 
-bool PlayMC::has_won() const { return root->result == RESULT_WIN; }
+bool PlayMC::has_won() const {
+  return root->result == RESULT_WIN;
+}
 
-bool PlayMC::has_drawn() const { return root->result == RESULT_DRAW; }
+bool PlayMC::has_drawn() const {
+  return root->result == RESULT_DRAW;
+}
 
 uintf PlayMC::write_requests(float game_states[]) const {
   for (uintf i = 0; i < GAME_STATE_SIZE * searched.size(); ++i) {
@@ -510,4 +518,6 @@ uintf PlayMC::write_requests(float game_states[]) const {
   return searched.size();
 }
 
-void PlayMC::print_game() const { std::cout << root->game << '\n'; }
+void PlayMC::print_game() const {
+  std::cout << root->game << '\n';
+}

--- a/corintho_ai/cpp/src/selfplayer.cpp
+++ b/corintho_ai/cpp/src/selfplayer.cpp
@@ -68,7 +68,9 @@ SelfPlayer::~SelfPlayer() {
   }
 }
 
-void SelfPlayer::do_first_iteration() { players[0].do_first_iteration(); }
+void SelfPlayer::do_first_iteration() {
+  players[0].do_first_iteration();
+}
 
 bool SelfPlayer::do_iteration(float evaluation[], float probabilities[]) {
   bool done_turn = players[to_play].do_iteration(evaluation, probabilities);
@@ -244,7 +246,9 @@ void SelfPlayer::write_requests(float *game_states) const {
   }
 }
 
-uintf SelfPlayer::count_samples() const { return samples.size(); }
+uintf SelfPlayer::count_samples() const {
+  return samples.size();
+}
 
 void SelfPlayer::write_samples(float *game_states, float *evaluation_samples,
                                float *probability_samples) const {

--- a/corintho_ai/cpp/src/trainmc.cpp
+++ b/corintho_ai/cpp/src/trainmc.cpp
@@ -238,9 +238,13 @@ bool TrainMC::receive_opp_move(uintf move_choice, const Game &game,
   return true;
 }
 
-const Game &TrainMC::get_game() const { return root->game; }
+const Game &TrainMC::get_game() const {
+  return root->game;
+}
 
-bool TrainMC::is_uninitialized() const { return root == nullptr; }
+bool TrainMC::is_uninitialized() const {
+  return root == nullptr;
+}
 
 void TrainMC::set_statics(uintf new_max_iterations, float new_c_puct,
                           float new_epsilon, uintf new_searches_per_eval) {
@@ -383,7 +387,7 @@ bool TrainMC::search() {
         float u = cur->get_probability(edge_index) * v_sqrt;
         if (u > max_value) {
           best_prev_node =
-              prev_node; // This should always be the last node in the list
+              prev_node;  // This should always be the last node in the list
           max_value = u;
           move_choice = cur->edges[edge_index].move_id;
         }

--- a/tests/cpp/move_test.cpp
+++ b/tests/cpp/move_test.cpp
@@ -1,51 +1,57 @@
 #include "move.h"
 #include "gtest/gtest.h"
+#include <iostream>
 
+// Very basic test for the Move class constructor
 TEST(MoveTest, Constructor) {
   // Create a move with id 0 and check the properties
   Move m0(0);
-  EXPECT_EQ(m0.mtype, 0);
-  EXPECT_EQ(m0.row1, 0);
-  EXPECT_EQ(m0.col1, 0);
-  EXPECT_EQ(m0.row2, 0);
-  EXPECT_EQ(m0.col2, 1);
+  EXPECT_EQ(m0.move_type(), Move::MoveType::kMove);
+  EXPECT_EQ(m0.row1(), 0);
+  EXPECT_EQ(m0.col1(), 0);
+  EXPECT_EQ(m0.row2(), 0);
+  EXPECT_EQ(m0.col2(), 1);
 
   // Create a move with id 48 and check the properties
   Move m48(48);
-  EXPECT_EQ(m48.mtype, 1);
-  EXPECT_EQ(m48.ptype, 0);
-  EXPECT_EQ(m48.row1, 0);
-  EXPECT_EQ(m48.col1, 0);
+  EXPECT_EQ(m48.move_type(), Move::MoveType::kPlace);
+  EXPECT_EQ(m48.piece_type(), 0);
+  EXPECT_EQ(m48.row1(), 0);
+  EXPECT_EQ(m48.col1(), 0);
 }
 
 TEST(MoveTest, EncodePlace) {
   // Test encoding of a place
-  EXPECT_EQ(encode_place(0, 0, 0), 48);
-  EXPECT_EQ(encode_place(1, 2, 3), 75);
+  EXPECT_EQ(encodePlace(0, 0, 0), 48);
+  EXPECT_EQ(encodePlace(1, 2, 3), 75);
 }
 
 TEST(MoveTest, EncodeMove) {
   // Test encoding of a move
-  EXPECT_EQ(encode_move(0, 0, 0, 1), 0);
-  EXPECT_EQ(encode_move(1, 2, 2, 2), 18);
+  EXPECT_EQ(encodeMove(0, 0, 0, 1), 0);
+  EXPECT_EQ(encodeMove(1, 2, 2, 2), 18);
 }
 
 TEST(MoveTest, RecoverMove) {
   // Test that decoding and encoding a move returns the same move
   for (int i = 0; i < 48; i++) {
     Move m(i);
-    EXPECT_EQ(encode_move(m.row1, m.col1, m.row2, m.col2), i);
+    //std::cerr << i << encodeMove(m.row1(), m.col1(), m.row2(), m.col2()) << std::endl;
+    EXPECT_EQ(encodeMove(m.row1(), m.col1(), m.row2(), m.col2()), i);
   }
   for (int i = 48; i < 96; i++) {
     Move m(i);
-    EXPECT_EQ(encode_place(m.ptype, m.row1, m.col1), i);
+    //std::cerr << i << encodePlace(m.piece_type(), m.row1(), m.col1()) << std::endl;
+    EXPECT_EQ(encodePlace(m.piece_type(), m.row1(), m.col1()), i);
   }
 }
 
 TEST(MoveTest, GetColName) {
   // Test column name conversion
-  EXPECT_EQ(get_col_name(0), 'a');
-  EXPECT_EQ(get_col_name(3), 'd');
+  EXPECT_EQ(getColName(0), 'a');
+  EXPECT_EQ(getColName(1), 'b');
+  EXPECT_EQ(getColName(2), 'c');
+  EXPECT_EQ(getColName(3), 'd');
 }
 
 TEST(MoveTest, PrintMove) {

--- a/tests/cpp/move_test.cpp
+++ b/tests/cpp/move_test.cpp
@@ -36,12 +36,14 @@ TEST(MoveTest, RecoverMove) {
   // Test that decoding and encoding a move returns the same move
   for (int i = 0; i < 48; i++) {
     Move m(i);
-    //std::cerr << i << encodeMove(m.row1(), m.col1(), m.row2(), m.col2()) << std::endl;
+    // std::cerr << i << encodeMove(m.row1(), m.col1(), m.row2(), m.col2()) <<
+    // std::endl;
     EXPECT_EQ(encodeMove(m.row1(), m.col1(), m.row2(), m.col2()), i);
   }
   for (int i = 48; i < 96; i++) {
     Move m(i);
-    //std::cerr << i << encodePlace(m.piece_type(), m.row1(), m.col1()) << std::endl;
+    // std::cerr << i << encodePlace(m.piece_type(), m.row1(), m.col1()) <<
+    // std::endl;
     EXPECT_EQ(encodePlace(m.piece_type(), m.row1(), m.col1()), i);
   }
 }


### PR DESCRIPTION
Use Google style guide to remake Move class.
Add clang-format specification file. Uses Google style guide and caps line at 80 characters.
Change game to use new Move names